### PR TITLE
chore: update codex to version 0.2.1 and codex app to 0.0.16

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,8 +35,8 @@
 
   | Package               | Link                                                                                                                                                   |
   | --------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------ |
-  | Codex                 | [`/ipfs/QmQjh7iCM97U7rAzALsJz7brwLttrwYirG6EKYhRAA3qys`](http://my.dappnode/installer/public/%2Fipfs%2FQmQjh7iCM97U7rAzALsJz7brwLttrwYirG6EKYhRAA3qys) |
-  | Codex with local Geth | [`/ipfs/Qmdpnv5Kev3moyobAKbKhU7of1DywJ5VEDKd3f2ti199tB`](http://my.dappnode/installer/public/%2Fipfs%2FQmdpnv5Kev3moyobAKbKhU7of1DywJ5VEDKd3f2ti199tB) |
+  | Codex                 | [`/ipfs/QmSmUyTgCZBL1Aa4MdVisvWSqdjvvQp6yZ1Nhg9BBWH3Jx`](http://my.dappnode/installer/public/%2Fipfs%2FQmSmUyTgCZBL1Aa4MdVisvWSqdjvvQp6yZ1Nhg9BBWH3Jx) |
+  | Codex with local Geth | [`/ipfs/QmUogXzAFpY5VHMQ83hhH2Rcbam6Kim6ekGP6mVxcgSwjk`](http://my.dappnode/installer/public/%2Fipfs%2FQmUogXzAFpY5VHMQ83hhH2Rcbam6Kim6ekGP6mVxcgSwjk) |
 
 
 ## Todo

--- a/dappnode_package.json
+++ b/dappnode_package.json
@@ -2,12 +2,12 @@
   "upstream": [
     {
       "repo": "codex-storage/nim-codex",
-      "version": "0.2.0",
+      "version": "0.2.1",
       "arg": "UPSTREAM_VERSION_CODEX_NODE"
     },
     {
       "repo": "codexstorage/codex-marketplace-ui",
-      "version": "0.0.13",
+      "version": "0.0.16",
       "arg": "UPSTREAM_VERSION_CODEX_APP"
     },
     {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,8 +5,8 @@ services:
       context: ./codex-node
       dockerfile: Dockerfile
       args:
-        UPSTREAM_VERSION_CODEX_NODE: 0.2.0
-    image: codex-node.public.dappnode.eth:0.1.0
+        UPSTREAM_VERSION_CODEX_NODE: 0.2.1
+    image: codex-node.public.dappnode.eth:0.2.1
     restart: unless-stopped
     environment:
       MODE: codex-node-with-marketplace
@@ -46,8 +46,8 @@ services:
       context: ./codex-app
       dockerfile: Dockerfile
       args:
-        UPSTREAM_VERSION_CODEX_APP: 0.0.13
-    image: codex-app.public.dappnode.eth:0.1.0
+        UPSTREAM_VERSION_CODEX_APP: 0.0.16
+    image: codex-app.public.dappnode.eth:0.0.16
     restart: unless-stopped
     logging:
       driver: json-file

--- a/package_variants/codex-local-geth/docker-compose.yml
+++ b/package_variants/codex-local-geth/docker-compose.yml
@@ -12,7 +12,7 @@ services:
       dockerfile: Dockerfile
       args:
         UPSTREAM_VERSION_GETH: v1.13.15
-    image: geth.codex.public.dappnode.eth:0.1.0
+    image: geth.codex.public.dappnode.eth:1.13.15
     restart: unless-stopped
     environment:
       NETWORK: testnet


### PR DESCRIPTION
PR update packages to use [Codex release - v0.2.1](https://github.com/codex-storage/nim-codex/releases/tag/v0.2.1).

And we performed the following
- Updated Codex version to the latest release
- Updated Codex App version to the latest release

Part of https://github.com/codex-storage/nim-codex/issues/1203.