### PR TITLE
chore: update codex to release 0.2.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,8 +35,8 @@
 
   | Package               | Link                                                                                                                                                   |
   | --------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------ |
-  | Codex                 | [`/ipfs/QmXRz7TivbsvAMLWEmBtFCPhGriAf2XkzdqrQ1vx5NdY7H`](http://my.dappnode/installer/public/%2Fipfs%2FQmXRz7TivbsvAMLWEmBtFCPhGriAf2XkzdqrQ1vx5NdY7H) |
-  | Codex with local Geth | [`/ipfs/QmU7qYTz7C7n4D6KPzxxu8NdivPjWHhJRoAE2iwmzTMqyQ`](http://my.dappnode/installer/public/%2Fipfs%2FQmU7qYTz7C7n4D6KPzxxu8NdivPjWHhJRoAE2iwmzTMqyQ) |
+  | Codex                 | [`/ipfs/QmX58nmcGWUG8stCEBQ1Fb6gjejrFpyqNLsavQgPxTPatu`](http://my.dappnode/installer/public/%2Fipfs%2FQmX58nmcGWUG8stCEBQ1Fb6gjejrFpyqNLsavQgPxTPatu) |
+  | Codex with local Geth | [`/ipfs/QmRR9uaUuJ866BTtaKXRcNLvzbPTX5JB6AmAGFaANhNGJH`](http://my.dappnode/installer/public/%2Fipfs%2FQmRR9uaUuJ866BTtaKXRcNLvzbPTX5JB6AmAGFaANhNGJH) |
 
 
 ## Todo

--- a/dappnode_package.json
+++ b/dappnode_package.json
@@ -2,7 +2,7 @@
   "upstream": [
     {
       "repo": "codex-storage/nim-codex",
-      "version": "0.2.1",
+      "version": "0.2.3",
       "arg": "UPSTREAM_VERSION_CODEX_NODE"
     },
     {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,8 +5,8 @@ services:
       context: ./codex-node
       dockerfile: Dockerfile
       args:
-        UPSTREAM_VERSION_CODEX_NODE: 0.2.1
-    image: codex-node.public.dappnode.eth:0.2.1
+        UPSTREAM_VERSION_CODEX_NODE: 0.2.3
+    image: codex-node.public.dappnode.eth:0.2.3
     restart: unless-stopped
     environment:
       MODE: codex-node-with-marketplace


### PR DESCRIPTION
PR update packages to use [Codex release - v0.2.3](https://github.com/codex-storage/nim-codex/releases/tag/v0.2.3).

Part of https://github.com/codex-storage/nim-codex/issues/1241.