### PR TITLE
chore: update codex to release 0.2.5

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,8 +35,8 @@
 
   | Package               | Link                                                                                                                                                   |
   | --------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------ |
-  | Codex                 | [`/ipfs/QmX58nmcGWUG8stCEBQ1Fb6gjejrFpyqNLsavQgPxTPatu`](http://my.dappnode/installer/public/%2Fipfs%2FQmX58nmcGWUG8stCEBQ1Fb6gjejrFpyqNLsavQgPxTPatu) |
-  | Codex with local Geth | [`/ipfs/QmRR9uaUuJ866BTtaKXRcNLvzbPTX5JB6AmAGFaANhNGJH`](http://my.dappnode/installer/public/%2Fipfs%2FQmRR9uaUuJ866BTtaKXRcNLvzbPTX5JB6AmAGFaANhNGJH) |
+  | Codex                 | [`/ipfs/QmRobj7vPQ7qJBG42iD8c75SAoMkG1pr1YetYD5QHJNrdz`](http://my.dappnode/installer/public/%2Fipfs%2FQmRobj7vPQ7qJBG42iD8c75SAoMkG1pr1YetYD5QHJNrdz) |
+  | Codex with local Geth | [`/ipfs/QmVwJtetY98Y1mVwQ3ULwha1tiE49jVn3DQEFigdtbRjj6`](http://my.dappnode/installer/public/%2Fipfs%2FQmVwJtetY98Y1mVwQ3ULwha1tiE49jVn3DQEFigdtbRjj6) |
 
 
 ## Todo

--- a/dappnode_package.json
+++ b/dappnode_package.json
@@ -2,7 +2,7 @@
   "upstream": [
     {
       "repo": "codex-storage/nim-codex",
-      "version": "0.2.3",
+      "version": "0.2.5",
       "arg": "UPSTREAM_VERSION_CODEX_NODE"
     },
     {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,8 +5,8 @@ services:
       context: ./codex-node
       dockerfile: Dockerfile
       args:
-        UPSTREAM_VERSION_CODEX_NODE: 0.2.3
-    image: codex-node.public.dappnode.eth:0.2.3
+        UPSTREAM_VERSION_CODEX_NODE: 0.2.5
+    image: codex-node.public.dappnode.eth:0.2.5
     restart: unless-stopped
     environment:
       MODE: codex-node-with-marketplace

--- a/docs/README.md
+++ b/docs/README.md
@@ -116,12 +116,12 @@
     export NVM_DIR="$HOME/.nvm"
     [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"  # This loads nvm
 
-    # Node 20
-    nvm install 20
+    # Node 22
+    nvm install 22
 
     # Check
     node --version
-    # v20.18.2
+    # v22.16.0
     ```
 
  4. Install [DAppNodeSDK](https://github.com/dappnode/DAppNodeSDK) on remote Dappnode
@@ -202,9 +202,8 @@
 
 ## Known issues
 
- 1. Latest [Node.js LTS release 22](https://nodejs.org/en/about/previous-releases), is not supported and we should use version 20.
- 2. During local package build it is uploaded to the local IPFS node, but in the Dappnode UI package avatar is loaded from the https://gateway.ipfs.dappnode.io, so most probably it will not be shown and it is not so clear what is the issue. Maybe something is wrong with avatar or something else? We can use default avatar, which is known by Dappnode IPFS gateway.
- 3. File `getting-started.md` is not specified in the official documentation, but it exists and is very usefully.
- 4. Dappnodesdk does not support `compose.yaml` file, [which is default and preferred](https://docs.docker.com/compose/intro/compose-application-model/).
- 5. Often time it can be more effective to [explorer existing packages](https://github.com/dappnode?q=DAppNodePackage&type=all&language=&sort=) configuration, than to use a documentation.
- 6. During the package build, Docker warn that ["the attribute `version` is obsolete"](https://docs.docker.com/reference/compose-file/version-and-name/#version-top-level-element-obsolete), but dappnodesdk will fail if we remove it - that is very confusing.
+ 1. During local package build it is uploaded to the local IPFS node, but in the Dappnode UI package avatar is loaded from the https://gateway.ipfs.dappnode.io, so most probably it will not be shown and it is not so clear what is the issue. Maybe something is wrong with avatar or something else? We can use default avatar, which is known by Dappnode IPFS gateway.
+ 2. File `getting-started.md` is not specified in the official documentation, but it exists and is very usefully.
+ 3. Dappnodesdk does not support `compose.yaml` file, [which is default and preferred](https://docs.docker.com/compose/intro/compose-application-model/).
+ 4. Often time it can be more effective to [explorer existing packages](https://github.com/dappnode?q=DAppNodePackage&type=all&language=&sort=) configuration, than to use a documentation.
+ 5. During the package build, Docker warn that ["the attribute `version` is obsolete"](https://docs.docker.com/reference/compose-file/version-and-name/#version-top-level-element-obsolete), but dappnodesdk will fail if we remove it - that is very confusing.


### PR DESCRIPTION
PR update packages to use [Codex release - v0.2.5](https://github.com/codex-storage/nim-codex/releases/tag/v0.2.5).

We also, updated guide to use node 22, which was fixed in https://github.com/dappnode/DAppNodeSDK/issues/454.

Part of https://github.com/codex-storage/nim-codex/issues/1282.